### PR TITLE
fix(CI): Resolve checkout failure due to shallow clone Problem

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        fetch-depth: 0
     - name: Bootstrap
       run: |
         cd /tmp


### PR DESCRIPTION
The CI workflow currently fails with an error: pathspec '...' did not match any file(s) known to git when executing the ./script/build script.

This is caused by the default "shallow clone" behavior (fetch-depth: 1) of the actions/checkout action in GitHub Actions, which only retrieves the most recent commit. When our build script needs to access or check out an older commit hash, it fails because that commit's history is not available in the cloned repository.

**Solution**

This PR modifies the .github/workflows/Build.yml file by adding the fetch-depth: 0 parameter to the actions/checkout step. This change forces the CI job to clone the full Git history of the repository, ensuring all commits are accessible. This resolves the checkout failure and allows the CI process to complete successfully.

**Additional Context & Recommendation**

This repository is developed and tested against a specific version of the openthread submodule. To prevent unexpected build failures or compatibility issues from upstream changes, it is recommended to disable automatic updates for the openthread submodule. This will help maintain a stable and predictable development environment.